### PR TITLE
Fix frontend build by adding alias and internal Slot

### DIFF
--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Slot } from "@radix-ui/react-slot";
+import { Slot } from "@/components/ui/slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/cn";
 

--- a/frontend/components/ui/slot.tsx
+++ b/frontend/components/ui/slot.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+
+/**
+ * A minimal Slot implementation used to compose components.
+ * It clones the child element and merges className and other props.
+ */
+export interface SlotProps extends React.HTMLAttributes<HTMLElement> {
+  children?: React.ReactNode;
+}
+
+export const Slot = React.forwardRef<HTMLElement, SlotProps>(
+  ({ children, ...props }, ref) =>
+    React.isValidElement(children)
+      ? React.cloneElement(
+          children as React.ReactElement,
+          {
+            ...(props as any),
+            ref,
+            className: [children.props.className, props.className]
+              .filter(Boolean)
+              .join(" "),
+          }
+        )
+      : React.createElement("span", { ...props, ref }, children)
+);
+
+Slot.displayName = "Slot";
+

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,7 +1,7 @@
 import type { Config } from "tailwindcss";
 
 export default {
-  darkMode: ["class"],
+  darkMode: "class",
   content: [
     "./app/**/*.{ts,tsx}",
     "./components/**/*.{ts,tsx}",

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
@@ -20,7 +20,11 @@
       {
         "name": "next"
       }
-    ]
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
## Summary
- configure TypeScript path alias and bundler module resolution
- add internal Slot component to avoid external dependency
- fix Tailwind dark mode configuration

## Testing
- `pnpm build`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68c1dfa7c090832c93047ddbbc58ad4f